### PR TITLE
Fix x,y null value cause error

### DIFF
--- a/lib/bubbles.dart
+++ b/lib/bubbles.dart
@@ -118,12 +118,16 @@ class Bubble {
 
   updatePosition() {
     var a = 180 - (direction + 90);
-    direction > 0 && direction < 180
+    if (x != null) {
+      direction > 0 && direction < 180
         ? x += speed * sin(direction) / sin(speed)
         : x -= speed * sin(direction) / sin(speed);
-    direction > 90 && direction < 270
+    }
+    if (y != null) {
+      direction > 90 && direction < 270
         ? y += speed * sin(a) / sin(speed)
         : y -= speed * sin(a) / sin(speed);
+    }
   }
 
   randomlyChangeDirectionIfEdgeReached(Size canvasSize) {


### PR DESCRIPTION
Debug Console:
```
The method '-' was called on null.
Receiver: null
Tried calling: -(0.9817616700677142)
```